### PR TITLE
fix: OUAT config

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     {
       "path": "ouat",
       "proxyMethod": "newRequest",
-      "url": "https://ouat.ac.in/quick-links"
+      "url": "https://ouat.ac.in"
     },
     {
       "path": "imd",


### PR DESCRIPTION
Currently https://provider-reverse-proxy.uat.bhasai.samagra.io/ouat directs to https://ouat.ac.in/quick-links/. 
We need it to direct us to just https://ouat.ac.in/ so that we can use that for download links also.